### PR TITLE
add git hook on push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+echo " * Please remember to run 'yarn run test:e2e-zkp' before opening a PR. *\n * note: The dev server should be running on port 3000 for the e2e tests to pass. *\n"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "eject": "react-scripts eject",
     "compile": "node circuits/scripts/compile.js",
     "gen-input": "npx tsx src/scripts/generate_input.ts",
-    "compile-all": "yarn gen-input && yarn compile email true"
+    "compile-all": "yarn gen-input && yarn compile email true",
+    "prepare": "husky install"
   },
   "eslintConfig": {
     "extends": [
@@ -92,6 +93,7 @@
     "@types/tar-stream": "^2.2.2",
     "browserstack-local": "^1.5.1",
     "browserstack-node-sdk": "^1.6.1",
+    "husky": "^8.0.3",
     "jest-junit": "^15.0.0",
     "msw": "^1.0.1",
     "nodemon": "^2.0.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8332,6 +8332,7 @@ __metadata:
     ethereumjs-abi: ^0.6.8
     ethers: ^5.7.1
     forge-std: ^1.1.2
+    husky: ^8.0.3
     jest-junit: ^15.0.0
     libmime: ^5.1.0
     localforage: ^1.10.0
@@ -11086,6 +11087,15 @@ __metadata:
   dependencies:
     ms: ^2.0.0
   checksum: 9c7a74a2827f9294c009266c82031030eae811ca87b0da3dceb8d6071b9bde22c9f3daef0469c3c533cc67a97d8a167cd9fc0389350e5f415f61a79b171ded16
+  languageName: node
+  linkType: hard
+
+"husky@npm:^8.0.3":
+  version: 8.0.3
+  resolution: "husky@npm:8.0.3"
+  bin:
+    husky: lib/bin.js
+  checksum: 837bc7e4413e58c1f2946d38fb050f5d7324c6f16b0fd66411ffce5703b294bd21429e8ba58711cd331951ee86ed529c5be4f76805959ff668a337dbfa82a1b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Gives a friendly reminder to run the e2e ZKP test locally on each push using husky and git hooks.